### PR TITLE
Convert gscam to use diagnostics 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,16 +48,17 @@ if(USE_ROSBUILD)
 
 else()
   # Use Catkin
-  find_package(catkin REQUIRED 
+  find_package(catkin REQUIRED
     COMPONENTS roscpp image_transport sensor_msgs nodelet
     camera_calibration_parsers camera_info_manager
+    mbot_diagnostics
     )
 
   catkin_package(
     INCLUDE_DIRS include
     LIBRARIES gscam
     CATKIN_DEPENDS roscpp nodelet image_transport sensor_msgs
-    camera_calibration_parsers camera_info_manager
+    camera_calibration_parsers camera_info_manager mbot_diagnostics
     DEPENDS GSTREAMER GST_APP
     )
 
@@ -123,8 +124,6 @@ endif()
 # Interim compatibility
 # Remove this in the next distribution release
 configure_file(scripts/gscam_node.in ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/gscam_node)
-file(COPY ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/gscam_node 
+file(COPY ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/gscam_node
   DESTINATION ${EXECUTABLE_OUTPUT_PATH}
   FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-
-

--- a/include/gscam/gscam.h
+++ b/include/gscam/gscam.h
@@ -15,8 +15,8 @@ extern "C"{
 #include <sensor_msgs/CameraInfo.h>
 #include <sensor_msgs/SetCameraInfo.h>
 
-#include <diagnostic_updater/diagnostic_updater.h>
-#include <diagnostic_updater/publisher.h>
+#include <mbot_diagnostics/diagnostic_updater.h>
+#include <mbot_diagnostics/output_diagnostic.h>
 
 #include <stdexcept>
 #include <string>
@@ -32,7 +32,6 @@ namespace gscam {
     bool init_stream();
     void publish_stream();
     void cleanup_stream();
-    void diagnostic_update(const ros::TimerEvent&);
 
     void run();
 
@@ -71,9 +70,8 @@ namespace gscam {
     ros::Publisher jpeg_pub_;
     ros::Publisher cinfo_pub_;
 
-    diagnostic_updater::Updater updater_;
-    diagnostic_updater::TopicDiagnostic* freq_diagnostic_;
-    ros::Timer diagnostic_update_timer_;
+    marble::DiagnosticUpdater* updater_;
+    marble::OutputDiagnostic* output_image_diagnostic_;
   };
 
 }

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,7 @@
   <build_depend>sensor_msgs</build_depend>
   <build_depend>camera_calibration_parsers</build_depend>
   <build_depend>camera_info_manager</build_depend>
+  <build_depend>mbot_diagnostics</build_depend>
 
   <run_depend>nodelet</run_depend>
   <run_depend>cv_bridge</run_depend>
@@ -33,11 +34,11 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>camera_calibration_parsers</run_depend>
   <run_depend>camera_info_manager</run_depend>
-  
+  <run_depend>mbot_diagnostics</run_depend>
+
   <export>
       <nodelet plugin="${prefix}/nodelet_plugins.xml"/>
   </export>
 
 
 </package>
-

--- a/src/gscam_node.cpp
+++ b/src/gscam_node.cpp
@@ -1,6 +1,7 @@
 
 #include <ros/ros.h>
 #include <gscam/gscam.h>
+#include <boost/thread/thread.hpp>
 
 int main(int argc, char** argv) {
   ros::init(argc, argv, "gscam_publisher");

--- a/src/gscam_nodelet.cpp
+++ b/src/gscam_nodelet.cpp
@@ -3,8 +3,9 @@
 #include <nodelet/nodelet.h>
 #include <pluginlib/class_list_macros.h>
 #include <gscam/gscam_nodelet.h>
+#include <boost/thread/thread.hpp>
 
-PLUGINLIB_EXPORT_CLASS(gscam::GSCamNodelet, nodelet::Nodelet) 
+PLUGINLIB_EXPORT_CLASS(gscam::GSCamNodelet, nodelet::Nodelet)
 
 namespace gscam {
   GSCamNodelet::GSCamNodelet() :
@@ -14,7 +15,7 @@ namespace gscam {
   {
   }
 
-  GSCamNodelet::~GSCamNodelet() 
+  GSCamNodelet::~GSCamNodelet()
   {
     stream_thread_->join();
   }


### PR DESCRIPTION
Emit a /diagnostic2 status for <camera name>/image_raw/compressed. ROS nodes using these images can then create dependency diagnostics for a particular camera's output.